### PR TITLE
Fix Streamlit entry imports and add dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,17 +48,11 @@ app/
    - Azure OpenAI resource with an embedding deployment
    - Azure Storage account with a container for ingestion
    - Optional: Cosmos DB for MongoDB vCore or Azure Database for PostgreSQL with pgvector
-3. Recommended Python packages (install via `pip install -r requirements.txt`):
-   - `streamlit`
-   - `azure-search-documents`
-   - `azure-identity`
-   - `azure-storage-blob`
-   - `pandas`
-   - `pdfplumber`
-   - `openai`
-   - `backoff`
+3. Install dependencies:
 
-> **Note:** The repository does not include a `requirements.txt`. Install packages manually or generate one based on the list above.
+   ```bash
+   pip install -r requirements.txt
+   ```
 
 ## Configuration
 
@@ -76,11 +70,14 @@ When running in Azure, the app prefers Managed Identity / AAD credentials via `D
 
 ## Running the app
 
-```bash
-streamlit run app/main.py
-```
+1. Install dependencies as shown above.
+2. Launch Streamlit from the repository root:
 
-Set the required environment variables before launching. The app will prompt for missing values within the sidebar.
+   ```bash
+   streamlit run app/main.py
+   ```
+
+3. Set the required environment variables before launching (or provide them in the sidebar when prompted).
 
 ## Usage overview
 

--- a/app/main.py
+++ b/app/main.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 import tempfile
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
+
+if __package__ in (None, ""):
+    # Allow running ``streamlit run app/main.py`` without installing the package.
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import pandas as pd
 import streamlit as st
@@ -16,17 +21,17 @@ from azure.search.documents import SearchClient  # type: ignore
 from azure.search.documents.indexes import SearchIndexClient, SearchIndexerClient  # type: ignore
 from azure.storage.blob import BlobServiceClient  # type: ignore
 
-from .azure_search.aliases import AliasOptions, swap_alias
-from .azure_search.index_schema import IndexSchemaOptions, VectorConfig, build_index_schema
-from .azure_search.indexers import DataSourceOptions, IndexerOptions, ensure_data_source, ensure_indexer, run_indexer
-from .azure_search.push_pipeline import PushIngestionPipeline, PushPipelineConfig, collect_chunks_from_text
-from .azure_search.rbac import get_default_credential, resolve_search_credential
-from .azure_search.skillsets import SkillsetOptions, build_skillset, build_skillset_payload
-from .chunking.textsplit_chunker import TextSplitOptions
-from .embeddings.azure_openai import EmbeddingConfig
-from .utils import hashing
-from .utils.logging import configure_logging, get_logger
-from .utils.validators import require_non_empty
+from app.azure_search.aliases import AliasOptions, swap_alias
+from app.azure_search.index_schema import IndexSchemaOptions, VectorConfig, build_index_schema
+from app.azure_search.indexers import DataSourceOptions, IndexerOptions, ensure_data_source, ensure_indexer, run_indexer
+from app.azure_search.push_pipeline import PushIngestionPipeline, PushPipelineConfig, collect_chunks_from_text
+from app.azure_search.rbac import get_default_credential, resolve_search_credential
+from app.azure_search.skillsets import SkillsetOptions, build_skillset, build_skillset_payload
+from app.chunking.textsplit_chunker import TextSplitOptions
+from app.embeddings.azure_openai import EmbeddingConfig
+from app.utils import hashing
+from app.utils.logging import configure_logging, get_logger
+from app.utils.validators import require_non_empty
 
 configure_logging()
 _LOGGER = get_logger(__name__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+streamlit>=1.33
+pandas>=2.0
+azure-search-documents>=11.4
+azure-identity>=1.16
+azure-storage-blob>=12.19
+backoff>=2.2
+openai>=1.14
+pdfplumber>=0.10


### PR DESCRIPTION
## Summary
- allow the Streamlit entrypoint to be executed directly by adjusting sys.path and switching to absolute package imports
- add a requirements.txt enumerating the app's runtime dependencies
- refresh the README to document dependency installation and the updated launch steps

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68da7f8ea9a483249d8064e8648d6abc