### PR TITLE
Load .env variables automatically for push ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ When running in Azure, the app prefers Managed Identity / AAD credentials via `D
    ```
 
 3. Set the required environment variables before launching (or provide them in the sidebar when prompted).
+   The app now loads a local `.env` file automatically at startup via [`python-dotenv`](https://pypi.org/project/python-dotenv/),
+   ensuring secrets such as `AZURE_OPENAI_API_KEY` are available for push ingestion even when not exported globally.
 
 ## Usage overview
 

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,8 @@ import time
 from pathlib import Path
 from typing import Any, Optional
 
+from dotenv import load_dotenv
+
 if __package__ in (None, ""):
     # Allow running ``streamlit run app/main.py`` without installing the package.
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
@@ -35,6 +37,8 @@ from app.utils.validators import require_non_empty
 
 configure_logging()
 _LOGGER = get_logger(__name__)
+
+load_dotenv()
 
 st.set_page_config(page_title="RAG Ingestor", layout="wide")
 st.title("Enterprise RAG Ingestor for Azure AI Search")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ azure-storage-blob>=12.19
 backoff>=2.2
 openai>=1.14
 pdfplumber>=0.10
+python-dotenv>=1.0


### PR DESCRIPTION
## Summary
- add python-dotenv to the application dependencies
- initialize python-dotenv before environment lookups in the Streamlit sidebar
- document automatic .env loading so push ingestion works with secrets stored locally

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68da8ea91d5c83249a15e9dd6dedcb3b